### PR TITLE
bump php version req to v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	],
 	"minimum-stability": "dev",
 	"require": {
-		"php": ">=5.4.0"
+		"php": ">=7.0.0"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
The null coalescing operator has been used in the code base.